### PR TITLE
Don't propagate Transfer-Encoding

### DIFF
--- a/no.php
+++ b/no.php
@@ -117,11 +117,13 @@ $headers_arr = preg_split( '/[\r\n]+/', $header_text );
   
 // Propagate headers to response.
 foreach ( $headers_arr as $header ) {
-    if ( preg_match( '/^Location:/i', $header ) ) {
-        # rewrite absolute local redirects to relative ones
-        $header = str_replace($backend_url, "/", $header);
+    if ( !preg_match( '/^Transfer-Encoding:/i', $header ) ) {
+        if ( preg_match( '/^Location:/i', $header ) ) {
+            # rewrite absolute local redirects to relative ones
+            $header = str_replace($backend_url, "/", $header);
+        }
+        header( $header );
     }
-    header( $header );
 }
 
 print $contents; # return the proxied request result to the browser


### PR DESCRIPTION
I was getting invalid chunking issues.  When I stopped propagating this header, it worked.

Using this as an ipv4 - ipv6 proxy.  Works great!