### PR TITLE
Avoid adding empty request headers

### DIFF
--- a/no.php
+++ b/no.php
@@ -51,13 +51,15 @@ function getRequestHeaders($multipart_delimiter=NULL) {
             preg_match("/^HTTPS/", $key) == 0
             ) {
                 $key = str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($key, 5)))));
-                array_push($headers, "$key: $value");
+                if ($key)
+                    array_push($headers, "$key: $value");
             }
         } elseif (preg_match("/^CONTENT_TYPE/", $key)) {
             if(preg_match("/^multipart/", strtolower($value)) && $multipart_delimiter) {
                 $key = "Content-Type";
                 $value = "multipart/form-data; boundary=" . $multipart_delimiter;
-                array_push($headers, "$key: $value");
+                if ($key)
+                    array_push($headers, "$key: $value");
             }
         }
     }


### PR DESCRIPTION
The `getRequestHeaders` function used by cURL sometimes adds empty headers, such as the "HTTP2" header (which is added with an empty key), to the cURL request headers; this results in cURL failing to process the request with a "Failed sending http request" error.

I believe a workaround for the issue would be to check whether the key is empty or not first before pushing the `$key: $value` combination to the request headers.

P.S thank you for this great script!