### PR TITLE
Rewrite Set-Cookie domain name to no.php host

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Supports:
 * Content types (HTTP payload) without discrimination
 * Redirects (internal redirects are rewritten to relative URIs)
 * Multipart content type
+* Cookies (with conversion of the backend domain to the no.php host)
 
 Does not support (or not tested):
 


### PR DESCRIPTION
The `Set-Cookie` header sometimes contains a `Domain=...` attribute which would prevent the cookie from being accepted by the browser since the domain accessing no.php is different than the cookie domain.

This pull request intercepts the `set-cookie` header and replaces the subdomains/main domain as per the `$backend_url` variable with the `no.php` host using regular expressions.