### PR TITLE
Remove redirection headers from curl response

### DIFF
--- a/no.php
+++ b/no.php
@@ -133,6 +133,7 @@ $contents = curl_exec( $curl ); # reverse proxy. the actual request to the backe
 curl_close( $curl ); # curl is done now
 
 
+$contents = preg_replace('/^HTTP\/1.1 3.*(?=HTTP\/1\.1)/sm', '', $contents); # remove redirection headers
 list( $header_text, $contents ) = preg_split( '/([\r\n][\r\n])\\1/', $contents, 2 );
 
 $headers_arr = preg_split( '/[\r\n]+/', $header_text ); 


### PR DESCRIPTION
This is a simple fix for cases when the proxied server performs redirection before sending the final response. 

In the current situation, curl is correctly set to follow redirects, however the code doesn't account for the fact that each time a redirect response is received, it's headers are also inserted into the result of "curl_exec". The $contents variable then contains multiple "header blocks" while it should only contain headers from the final response.

This is fixed by removing the 3xx header blocks from the $contents variable.