### PR TITLE
Pass REMOTE_USER to the backend

### DIFF
--- a/no.php
+++ b/no.php
@@ -68,6 +68,8 @@ function getRequestHeaders($multipart_delimiter=NULL) {
                 // Handle application/json
                 array_push($headers, "$key: $value");
             }
+        } elseif ($key === 'REMOTE_USER') {
+            array_push($headers, "X-Forwarded-User: $value");
         }
     }
     return $headers;

--- a/no.php
+++ b/no.php
@@ -46,6 +46,10 @@ $url = $backend_url . $request_uri;
 function getRequestHeaders($multipart_delimiter=NULL) {
     $headers = array();
     foreach($_SERVER as $key => $value) {
+        if ($key === 'HTTP_X_FORWARDED_USER') {
+            # Ignore the "X-Forwarded-User" header requested by the user.
+            continue;
+        }
         if(preg_match("/^HTTP/", $key)) { # only keep HTTP headers
             if(preg_match("/^HTTP_HOST/", $key) == 0 && # let curl set the actual host/proxy
             preg_match("/^HTTP_ORIGIN/", $key) == 0 &&


### PR DESCRIPTION
We would like to pass `REMOTE_USER` to the backend and use it for authentication.

`REMOTE_USER` is added because it was not included in the target to be passed.
It is passed to the backend with the ` X-Forwarded-User` header.
And ignore the `X-Forwarded-User` header requested by the user.