### PR TITLE
Fix `Undefined array key -1` warning

### DIFF
--- a/no.php
+++ b/no.php
@@ -75,7 +75,14 @@ function getRequestHeaders($multipart_delimiter=NULL) {
 
 function build_domain_regex($hostname)
 {
+	if (filter_var($hostname, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+		return $hostname;
+	}
 	$names = explode('.', $hostname); //assumes main domain is the TLD
+	if (count($names) === 1) {
+		return $hostname;
+	}
+
 	$regex = "";
 	for ($i= 0; $i < count ($names)-2; $i++)
 	{


### PR DESCRIPTION
Warning if `localhost` is specified:

```
PHP Warning:  Undefined array key -1
```

Also changed to return $hostname as it is when IP is specified.