### PR TITLE
Fix `$request_uri` replacement

### DIFF
--- a/no.php
+++ b/no.php
@@ -31,7 +31,7 @@ $uri_rel = "subdir/no.php"; # URI to this file relative to public_html
 
 $request_includes_nophp_uri = true;
 if ( $request_includes_nophp_uri == false) {
-    $request_uri = str_replace( $uri_rel, "/", $request_uri );
+        $request_uri = str_replace( rtrim($uri_rel, '/'), '', $request_uri );
 }
 
 $is_ruby_on_rails = false;

--- a/no.php
+++ b/no.php
@@ -31,7 +31,8 @@ $uri_rel = "subdir/no.php"; # URI to this file relative to public_html
 
 $request_includes_nophp_uri = true;
 if ( $request_includes_nophp_uri == false) {
-        $request_uri = str_replace( rtrim($uri_rel, '/'), '', $request_uri );
+    $pattern =  '/' . preg_quote(rtrim($uri_rel, '/'), '/') . '/';
+    $request_uri = preg_replace($pattern, '', $request_uri , 1);
 }
 
 $is_ruby_on_rails = false;


### PR DESCRIPTION
`$request_uri` may be headed by two slashes.

```php
$uri_rel = '/path/no.php';
$request_uri = '/path/no.php/page';
echo str_replace( $uri_rel, '/', $request_uri );

// -> "//page"
```

If the same string exists in the path, it will not be replaced as expected.
    
```php
$uri_rel = '/path';
$request_uri = '/path/path1/page';
echo str_replace( $uri_rel, '/', $request_uri );
    
// -> "//1/page"
```
    
So, we'll replace only the first one.