### PR TITLE
Skip `HTTP_CONTENT_TYPE` because the request to the backend contains two `Content-Type` headers

### DIFF
--- a/no.php
+++ b/no.php
@@ -49,6 +49,7 @@ function getRequestHeaders($multipart_delimiter=NULL) {
         if(preg_match("/^HTTP/", $key)) { # only keep HTTP headers
             if(preg_match("/^HTTP_HOST/", $key) == 0 && # let curl set the actual host/proxy
             preg_match("/^HTTP_ORIGIN/", $key) == 0 &&
+            preg_match("/^HTTP_CONTENT_TYPE/", $key) == 0 && # Set at `$key == "CONTENT_TYPE"`
             preg_match("/^HTTP_CONTENT_LEN/", $key) == 0 && # let curl set the actual content length
             preg_match("/^HTTPS/", $key) == 0
             ) {

--- a/no.php
+++ b/no.php
@@ -58,17 +58,11 @@ function getRequestHeaders($multipart_delimiter=NULL) {
                     array_push($headers, "$key: $value");
             }
         } elseif (preg_match("/^CONTENT_TYPE/", $key)) {
-
             $key = "Content-Type";
-
             if(preg_match("/^multipart/", strtolower($value)) && $multipart_delimiter) {
                 $value = "multipart/form-data; boundary=" . $multipart_delimiter;
-                array_push($headers, "$key: $value");
             }
-            else if(preg_match("/^application\/json/", strtolower($value))) {
-                // Handle application/json
-                array_push($headers, "$key: $value");
-            }
+            array_push($headers, "$key: $value");
         }
     }
     return $headers;


### PR DESCRIPTION
Since `$_SERVER` contains `CONTENT_TYPE`, we'll use that instead.